### PR TITLE
Use inspect.getfullargspec() if available

### DIFF
--- a/flask_redis.py
+++ b/flask_redis.py
@@ -154,7 +154,10 @@ class Redis(object):
             app.config[key('UNIX_SOCKET_PATH')] = host
 
         # Read connection args spec, exclude self from list of possible
-        args = inspect.getargspec(klass.__init__).args
+        try:
+            args = inspect.getfullargspec(klass.__init__).args
+        except AttributeError:
+            args = inspect.getargspec(klass.__init__).args
         args.remove('self')
 
         # Prepare keyword arguments


### PR DESCRIPTION
 inspect.getargspec() is deprecated, use inspect.signature() or inspect.getfullargspec().
as [inspect.getargspec](https://docs.python.org/3/library/inspect.html#inspect.getargspec) is desprecated since python 3.0, it's better to use inspect.getfullargspec instead.
I rewrote it after reading this issue of [tensorflow/probability](https://github.com/tensorflow/probability/pull/98/commits/5449164353652b98808f1e4a589a731b7e692711).