### PR TITLE
Support subclasses of the Redis client class.

### DIFF
--- a/flask_redis.py
+++ b/flask_redis.py
@@ -153,27 +153,7 @@ class Redis(object):
             app.config.pop(key('HOST'))
             app.config[key('UNIX_SOCKET_PATH')] = host
 
-        # Read connection args spec, exclude self from list of possible
-        all_klasses = [klass] + [
-            subklass
-            for subklass in klass.__bases__
-            if subklass is not object
-        ]
-
-        all_args = []
-        for subklass in all_klasses:
-            try:
-                args = inspect.getfullargspec(subklass.__init__).args
-            except AttributeError:
-                args = inspect.getargspec(subklass.__init__).args
-            for arg in args:
-                if arg in args:
-                    continue
-                all_args.append(arg)
-
-        args.remove('self')
-
-        # Prepare keyword arguments
+        args = self._build_connection_args(klass)
         kwargs = dict([(arg, convert(arg, app.config[key(arg.upper())]))
                        for arg in args
                        if key(arg.upper()) in app.config])
@@ -184,6 +164,25 @@ class Redis(object):
 
         # Include public methods to current instance
         self._include_public_methods(connection)
+
+    def _build_connection_args(self, klass):
+        """Read connection args spec, exclude self from list of possible
+
+        :param klass: Redis connection class.
+        """
+        bases = [base for base in klass.__bases__ if base is not object]
+        all_args = []
+        for cls in [klass] + bases:
+            try:
+                args = inspect.getfullargspec(cls.__init__).args
+            except AttributeError:
+                args = inspect.getargspec(cls.__init__).args
+            for arg in args:
+                if arg in all_args:
+                    continue
+                all_args.append(arg)
+        all_args.remove('self')
+        return all_args
 
     def _include_public_methods(self, connection):
         """Include public methods from Redis connection to current instance.

--- a/flask_redis.py
+++ b/flask_redis.py
@@ -154,10 +154,23 @@ class Redis(object):
             app.config[key('UNIX_SOCKET_PATH')] = host
 
         # Read connection args spec, exclude self from list of possible
-        try:
-            args = inspect.getfullargspec(klass.__init__).args
-        except AttributeError:
-            args = inspect.getargspec(klass.__init__).args
+        all_klasses = [klass] + [
+            subklass
+            for subklass in klass.__bases__
+            if subklass is not object
+        ]
+
+        all_args = []
+        for subklass in all_klasses:
+            try:
+                args = inspect.getfullargspec(subklass.__init__).args
+            except AttributeError:
+                args = inspect.getargspec(subklass.__init__).args
+            for arg in args:
+                if arg in args:
+                    continue
+                all_args.append(arg)
+
         args.remove('self')
 
         # Prepare keyword arguments

--- a/testapp/tests.py
+++ b/testapp/tests.py
@@ -33,6 +33,14 @@ class InheritFromStrictRedis(StrictRedis):
     """Dummy class inherited from Strict Redis."""
 
 
+class CustomInitStrictRedis(StrictRedis):
+    """Dummy class that has own __init__ defined"""
+
+    def __init__(self, foo="bar", *args, **kwargs):
+        super(CustomInitStrictRedis, self).__init__(*args, **kwargs)
+        self.foo = foo
+
+
 def get_context(app):
     creator = getattr(app, 'app_context', app.test_request_context)
     return creator()
@@ -120,6 +128,16 @@ class TestFlaskAndRedis(TestCase):
                               REDIS_URL=TEST_REDIS_URL)
         redis = Redis(app)
         redis.ping()
+
+    def test_class_custom_init(self):
+        app = self.create_app(REDIS_CLASS=CustomInitStrictRedis,
+                              REDIS_URL='redis://127.0.0.1:6379/1')
+        redis = Redis(app)
+        redis.ping()
+        self.assertEqual(redis.connection.foo, "bar")
+        self.assertEqual(
+            redis.connection.connection_pool.connection_kwargs['db'], '1'
+        )
 
     def test_class_from_string(self):
         app = self.create_app(REDIS_CLASS='redis.Redis',


### PR DESCRIPTION
This basically makes sure that Redis-py subclasses such as [Walrus](https://walrus.rtfd.org/)
are correctly working with the argument inspection.